### PR TITLE
Switch energy efficient and max clock speeds to use the HSI clock. Th…

### DIFF
--- a/hal/rcc/rcc.h
+++ b/hal/rcc/rcc.h
@@ -16,8 +16,8 @@ class Rcc {
   virtual void set_clock_to_energy_efficient_speed() = 0;
 
   // Restore the clock speed to the last requested setting after waking from stop mode. When exiting
-  // stop mode, the clock defaults to a 4 MHz MSI clock, possibly with no PLL setting. This method
-  // is a shorthand to restore the previous clock setting.
+  // stop mode, the clock defaults to a 4 MHz MSI clock or the 16 MHz HSI, possibly with no PLL
+  // setting. This method is a shorthand to restore the previous clock setting.
   virtual void restore_clock_speed() = 0;
 };
 

--- a/hal/rcc/stm32l4xx_rcc.cc
+++ b/hal/rcc/stm32l4xx_rcc.cc
@@ -9,28 +9,32 @@ void RccStm32L4xx::set_clock_to_max_speed() {
   // The current implementation puts SYSCLK signal as well as peripheral buses at 80 MHz. This speed
   // requires four flash wait states per operation.
 
+  __HAL_RCC_HSI_ENABLE();
+  while (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == 0) {
+    // Busy loop until the oscillator is available.
+  }
+
   // Bring up the internal regulator voltage to its normal level. The system will be very unstable
   // if we are undervolting while trying to run at a higher clock speed.
   HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1);
 
-  // Set the MSI oscillator to 4 MHz and use the PLL to multiple the speed up to a total of 80 MHz.
+  // The HSI oscillator is a non-configurable 16 MHz, which is the speed we want for efficiency.
   RCC_OscInitTypeDef RCC_OscInitStruct{};
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = 0;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
   RCC_OscInitStruct.PLL.PLLM = 1;
-  RCC_OscInitStruct.PLL.PLLN = 40;
-  // Note that we do not configure PLLP, since that parameter is not available on the STM32L412, and
-  // we don't use that signal for anything.
-  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
+  RCC_OscInitStruct.PLL.PLLN = 10;
   RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV7;
+  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
   HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
   // Configure the flash latency as well as initialize the CPU, AHB and APB bus clocks to use the
-  // MSI without any divider.
+  // SYSCLK and HCLK without any dividers.
   RCC_ClkInitTypeDef RCC_ClkInitStruct{};
   RCC_ClkInitStruct.ClockType =
       RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
@@ -42,7 +46,9 @@ void RccStm32L4xx::set_clock_to_max_speed() {
   // Note that we also designate the flash latency here as having a one cycle wait state.
   HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4);
 
-  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
+  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
+
+  __HAL_RCC_MSI_DISABLE();
 
   clock_configuration_ = ClockConfiguration::MAX_SPEED;
 }
@@ -52,28 +58,25 @@ void RccStm32L4xx::set_clock_to_energy_efficient_speed() {
   // is the maximum speed allowed when undervolting the system. This speed requires zero flash wait
   // state per operation.
 
-  // Set the MSI oscillator to 4 MHz and use the PLL to multiple the speed up to a total of 16 MHz.
+  __HAL_RCC_HSI_ENABLE();
+  while (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == 0) {
+    // Busy loop until the oscillator is available.
+  }
+
+  // The HSI oscillator is a non-configurable 16 MHz, which is the speed we want for efficiency.
   RCC_OscInitTypeDef RCC_OscInitStruct{};
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = 0;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_6;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_MSI;
-  RCC_OscInitStruct.PLL.PLLM = 1;
-  RCC_OscInitStruct.PLL.PLLN = 16;
-  // Note that we do not configure PLLP, since that parameter is not available on the STM32L412, and
-  // we don't use that signal for anything.
-  RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV4;
-  RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV4;
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
   HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
   // Configure the flash latency as well as initialize the CPU, AHB and APB bus clocks to use the
   // MSI without any divider.
   RCC_ClkInitTypeDef RCC_ClkInitStruct{};
   RCC_ClkInitStruct.ClockType =
-      RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+      RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSI;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
@@ -84,12 +87,19 @@ void RccStm32L4xx::set_clock_to_energy_efficient_speed() {
   // Configure the main internal regulator output voltage to undervolt the CPU to save power.
   HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE2);
 
-  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
+  __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_HSI);
+
+  __HAL_RCC_MSI_DISABLE();
 
   clock_configuration_ = ClockConfiguration::ENERGY_EFFICIENT_SPEED;
 }
 
 void RccStm32L4xx::set_clock_to_min_speed() {
+  __HAL_RCC_MSI_ENABLE();
+  while (__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) == 0) {
+    // Busy loop until the oscillator is available.
+  }
+
   // Set the MSI oscillator to 100 kHz. This is its minimum speed.
   // Bypass the PLL.
   RCC_OscInitTypeDef RCC_OscInitStruct{};
@@ -118,6 +128,8 @@ void RccStm32L4xx::set_clock_to_min_speed() {
   HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE2);
 
   __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(RCC_STOP_WAKEUPCLOCK_MSI);
+
+  __HAL_RCC_HSI_DISABLE();
 
   clock_configuration_ = ClockConfiguration::MIN_SPEED;
 }


### PR DESCRIPTION
…e HSI is more stable than the MSI and may be more energy efficient at a SYSCLK of 16 MHz which seems to be the most energy efficient speed for process-heavy workloads.