### PR TITLE
Refactor SerialWire class to allow for serial wire operations without…

### DIFF
--- a/bringup/BUILD.bazel
+++ b/bringup/BUILD.bazel
@@ -464,6 +464,31 @@ cc_binary(
 )
 
 cc_binary(
+    name = "read_target_swdp_id_with_reset.elf",
+    srcs = [
+        "read_target_swdp_id_with_reset.cc",
+    ],
+    additional_linker_inputs = [
+        ":linker_script",
+    ],
+    linkopts = ["-Wl,-T$(execpath :linker_script)"],
+    target_compatible_with = select({
+        "//platforms:no_gpio": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//base",
+        "//hal",
+        "//hal/board",
+        "//hal/gpio",
+        "//hal/programmer",
+        "//scheduler",
+        "//serial_wire",
+        "//time:embedded_clock",
+    ],
+)
+
+cc_binary(
     name = "reset_target_board.elf",
     srcs = [
         "reset_target_board.cc",

--- a/bringup/read_target_swdp_id_with_reset.cc
+++ b/bringup/read_target_swdp_id_with_reset.cc
@@ -43,6 +43,7 @@ tvsc::scheduler::Task<ClockType> read_target_swdp_id(BoardType &board) {
 
       tvsc::serial_wire::SerialWire swd{programmer_peripheral};
 
+      swd.reset_target();
       swd.initialize_swd();
 
       target_swdp_id = swd.read_id_code();

--- a/serial_wire/serial_wire.cc
+++ b/serial_wire/serial_wire.cc
@@ -45,21 +45,24 @@ using namespace std::chrono_literals;
 }
 
 /**
+ * Reset the target board.
+ */
+void SerialWire::reset_target() {
+  programmer_.initiate_target_board_reset();
+  time::EmbeddedClock::clock().wait(programmer_.RESET_HOLD_TIME);
+  programmer_.conclude_target_board_reset();
+}
+
+/**
  * Initialize, or re-initialize, the target to accept SWD commands.
  */
 uint32_t SerialWire::initialize_swd() {
-  using namespace std::chrono_literals;
-
   // Special value to switch from JTAG to SWD. This value is part of the SWD specification. It can
   // also be found on page 1577 of the datasheet
   // https://www.st.com/resource/en/reference_manual/rm0394-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf.
   // Note that the datasheet gives the bits in an order such that the MSB needs to be sent first.
   // Our send routines send the LSB first. This value is reversed from the one in the datasheet.
   static constexpr uint16_t JTAG_SWD_SWITCHING_SEQUENCE{0xe79e};
-
-  programmer_.initiate_target_board_reset();
-  time::EmbeddedClock::clock().wait(programmer_.RESET_HOLD_TIME);
-  programmer_.conclude_target_board_reset();
 
   // The SWD spec requires at least 50 clock cycles with SWDIO high to trigger the JTAG/SWD switch
   // sequence. We send multiple 32-bit values of all ones to accomplish this reset.

--- a/serial_wire/serial_wire.h
+++ b/serial_wire/serial_wire.h
@@ -46,16 +46,15 @@ class SerialWire final {
              std::chrono::nanoseconds clock_period = 100us)
       : programmer_(programmer_peripheral.access()) {
     programmer_.set_clock_period(clock_period);
-    initialize_swd();
   }
 
   uint32_t read_id_code() {
     uint32_t id{};
-    if (!swd_dp_read(0x00, id)) {
-      // id = 0;
-    }
+    swd_dp_read(0x00, id);
     return id;
   }
+
+  void reset_target();
 
   /**
    * Initialize, or re-initialize, the target to accept SWD commands.


### PR DESCRIPTION
… putting the target board in reset first. Add/modify bringup scripts to enable reading the IDCODE with and without resetting the target board first.