### PR TITLE
Switch TimeType to a signed integer type

### DIFF
--- a/bringup/blink.h
+++ b/bringup/blink.h
@@ -12,8 +12,8 @@ namespace tvsc::bringup {
 
 using namespace std::chrono_literals;
 
-template <typename ClockType,
-          uint64_t DURATION_MS = 365UL * 24 * 60 * 60 * 1000 /* one year in milliseconds */>
+template <typename ClockType, tvsc::hal::TimeType DURATION_MS =
+                                  /* one year in milliseconds */ 365LL * 24 * 60 * 60 * 1000>
 tvsc::scheduler::Task<ClockType> blink(ClockType& clock,
                                        tvsc::hal::gpio::GpioPeripheral& gpio_peripheral,
                                        tvsc::hal::gpio::Pin pin,
@@ -21,10 +21,10 @@ tvsc::scheduler::Task<ClockType> blink(ClockType& clock,
   tvsc::hal::gpio::Gpio gpio{gpio_peripheral.access()};
 
   gpio.set_pin_mode(pin, tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);
-  const uint64_t stop_time_ms{clock.current_time_millis() + DURATION_MS};
+  const auto stop_time{clock.current_time() + std::chrono::milliseconds(DURATION_MS)};
 
   gpio.write_pin(pin, 0);
-  while (clock.current_time_millis() < stop_time_ms) {
+  while (clock.current_time() < stop_time) {
     gpio.toggle_pin(pin);
     co_yield delay;
   }

--- a/bringup/blink_multiple_leds.cc
+++ b/bringup/blink_multiple_leds.cc
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
 
   Scheduler<ClockType, QUEUE_SIZE> scheduler{board.rcc()};
 
-  static constexpr uint64_t DURATION_MULTIPLES[] = {4, 3, 2};
+  static constexpr int DURATION_MULTIPLES[] = {4, 3, 2};
   static_assert(BoardType::NUM_DEBUG_LEDS < 4, "Need to implement blink for more LEDs");
 
   for (size_t i = 0; i < BoardType::NUM_DEBUG_LEDS; ++i) {

--- a/hal/time_type.h
+++ b/hal/time_type.h
@@ -4,6 +4,6 @@
 
 namespace tvsc::hal {
 
-using TimeType = uint64_t;
+using TimeType = int64_t;
 
 }  // namespace tvsc::hal


### PR DESCRIPTION
Switch TimeType (the integral type used for time across the system when std::chrono types are inappropriate) to a signed type to properly handle negative durations. Negative durations arise when differences between time points are mishandled. This change allows negative durations to exist and be handled correctly with standard comparisons and no extra logic.