### PR TITLE
Allow the pin and GPIO port numbers to be passed as a single object 

### DIFF
--- a/bringup/blink.cc
+++ b/bringup/blink.cc
@@ -10,8 +10,7 @@ using namespace tvsc::system;
 int main(int argc, char* argv[]) {
   tvsc::initialize(&argc, &argv);
 
-  System::scheduler().add_task(blink(System::board().gpio<System::BoardType::DEBUG_LED_PORT>(),
-                                     System::BoardType::DEBUG_LED_PIN));
+  System::scheduler().add_task(blink(System::board().debug_led()));
   System::scheduler().add_task(quit());
 
   System::scheduler().start();

--- a/bringup/blink.h
+++ b/bringup/blink.h
@@ -15,7 +15,7 @@ using namespace std::chrono_literals;
 template <tvsc::hal::TimeType DURATION_MS =
               /* one year in milliseconds */ 365LL * 24 * 60 * 60 * 1000>
 tvsc::system::System::Task blink(tvsc::hal::gpio::GpioPeripheral& gpio_peripheral,
-                                 tvsc::hal::gpio::Pin pin,
+                                 tvsc::hal::gpio::PinNumber pin,
                                  typename system::System::ClockType::duration delay = 500ms) {
   tvsc::hal::gpio::Gpio gpio{gpio_peripheral.access()};
 
@@ -34,7 +34,7 @@ tvsc::system::System::Task blink(tvsc::hal::gpio::GpioPeripheral& gpio_periphera
 
 tvsc::system::System::Task blink_on_success(std::function<bool()> is_success,
                                             tvsc::hal::gpio::GpioPeripheral& led_peripheral,
-                                            tvsc::hal::gpio::Pin led_pin) {
+                                            tvsc::hal::gpio::PinNumber led_pin) {
   tvsc::hal::gpio::Gpio led_gpio{led_peripheral.access()};
 
   led_gpio.set_pin_mode(led_pin, tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);

--- a/bringup/blink.h
+++ b/bringup/blink.h
@@ -14,21 +14,20 @@ using namespace std::chrono_literals;
 
 template <tvsc::hal::TimeType DURATION_MS =
               /* one year in milliseconds */ 365LL * 24 * 60 * 60 * 1000>
-tvsc::system::System::Task blink(tvsc::hal::gpio::GpioPeripheral& gpio_peripheral,
-                                 tvsc::hal::gpio::PinNumber pin,
+tvsc::system::System::Task blink(tvsc::hal::gpio::PinPeripheral led_peripheral,
                                  typename system::System::ClockType::duration delay = 500ms) {
-  tvsc::hal::gpio::Gpio gpio{gpio_peripheral.access()};
+  tvsc::hal::gpio::Pin led{led_peripheral.access()};
 
-  gpio.set_pin_mode(pin, tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);
+  led.set_pin_mode(tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);
   const auto stop_time{system::System::clock().current_time() +
                        std::chrono::milliseconds(DURATION_MS)};
 
-  gpio.write_pin(pin, 0);
+  led.write_pin(0);
   while (system::System::clock().current_time() < stop_time) {
-    gpio.toggle_pin(pin);
+    led.toggle_pin();
     co_yield delay;
   }
-  gpio.write_pin(pin, 0);
+  led.write_pin(0);
   co_return;
 }
 

--- a/bringup/blink_multiple_leds.cc
+++ b/bringup/blink_multiple_leds.cc
@@ -19,9 +19,8 @@ int main(int argc, char* argv[]) {
   static_assert(BoardType::NUM_DEBUG_LEDS < 4, "Need to implement blink for more LEDs");
 
   for (size_t i = 0; i < BoardType::NUM_DEBUG_LEDS; ++i) {
-    auto& gpio{System::board().gpio(BoardType::DEBUG_LED_PORTS[i])};
     System::scheduler().add_task(
-        blink(gpio, BoardType::DEBUG_LED_PINS[i], DURATION_MULTIPLES[i] * BASE_DURATION));
+        blink(System::board().debug_led(i), DURATION_MULTIPLES[i] * BASE_DURATION));
   }
 
   System::scheduler().start();

--- a/bringup/can_rx.h
+++ b/bringup/can_rx.h
@@ -13,7 +13,7 @@ template <size_t QUEUE_SIZE, size_t NUM_HANDLERS>
 tvsc::system::System::Task can_bus_receive(
     tvsc::hal::can_bus::CanBusPeripheral& can_peripheral,
     tvsc::message::CanBusMessageQueue<QUEUE_SIZE, NUM_HANDLERS>& queue,
-    tvsc::hal::gpio::GpioPeripheral& gpio_peripheral, tvsc::hal::gpio::Pin pin) {
+    tvsc::hal::gpio::GpioPeripheral& gpio_peripheral, tvsc::hal::gpio::PinNumber pin) {
   using namespace std::chrono_literals;
   using namespace tvsc::hal::can_bus;
 

--- a/bringup/flash_target.h
+++ b/bringup/flash_target.h
@@ -29,7 +29,7 @@ namespace tvsc::bringup {
 
 tvsc::system::System::Task flash_target(
     tvsc::hal::programmer::ProgrammerPeripheral &programmer_peripheral,
-    tvsc::hal::gpio::GpioPeripheral &debug_led_peripheral, tvsc::hal::gpio::Pin debug_led_pin) {
+    tvsc::hal::gpio::GpioPeripheral &debug_led_peripheral, tvsc::hal::gpio::PinNumber debug_led_pin) {
   using namespace std::chrono_literals;
   using namespace tvsc::hal::gpio;
   using namespace tvsc::serial_wire;

--- a/bringup/monitor_imu.cc
+++ b/bringup/monitor_imu.cc
@@ -27,8 +27,7 @@ int main(int argc, char* argv[]) {
   scheduler.add_task(monitor_imu(board.imu1(), imu1_reading, 1ms));
   // scheduler.add_task(monitor_imu<ClockType>(board.imu2(), imu2_reading,
   // 1ms));
-  scheduler.add_task(blink(board.gpio<System::BoardType::DEBUG_LED_PORT>(),
-                           System::BoardType::DEBUG_LED_PIN, 500ms));
+  scheduler.add_task(blink(board.debug_led()));
   scheduler.add_task(run_watchdog(board.iwdg()));
 
   scheduler.start();

--- a/bringup/monitor_power.cc
+++ b/bringup/monitor_power.cc
@@ -34,8 +34,7 @@ int main(int argc, char* argv[]) {
   auto& scheduler{System::scheduler()};
   scheduler.add_task(monitor_power(board.power_monitor1(), power_monitor1, 1000ms));
   scheduler.add_task(monitor_power(board.power_monitor2(), power_monitor2, 1000ms));
-  scheduler.add_task(blink(board.gpio<System::BoardType::DEBUG_LED_PORT>(),
-                           System::BoardType::DEBUG_LED_PIN, 500ms));
+  scheduler.add_task(blink(board.debug_led()));
   scheduler.add_task(run_watchdog(board.iwdg()));
 
   scheduler.start();

--- a/bringup/random_blink.h
+++ b/bringup/random_blink.h
@@ -7,7 +7,7 @@
 namespace tvsc::bringup {
 
 tvsc::system::System::Task blink_randomly(tvsc::hal::gpio::GpioPeripheral& gpio_peripheral,
-                                          tvsc::hal::gpio::Pin pin) {
+                                          tvsc::hal::gpio::PinNumber pin) {
   auto gpio{gpio_peripheral.access()};
   gpio.set_pin_mode(pin, tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);
   gpio.write_pin(pin, 0);

--- a/bringup/read_board_id.h
+++ b/bringup/read_board_id.h
@@ -17,8 +17,8 @@ namespace tvsc::bringup {
 template <typename ClockType>
 tvsc::hal::board_identification::BoardId read_board_id(
     ClockType& clock, tvsc::hal::gpio::GpioPeripheral& id_power_peripheral,
-    tvsc::hal::gpio::Pin power_pin, tvsc::hal::gpio::GpioPeripheral& id_sense_peripheral,
-    tvsc::hal::gpio::Pin sense_pin, tvsc::hal::adc::AdcPeripheral& adc_peripheral) {
+    tvsc::hal::gpio::PinNumber power_pin, tvsc::hal::gpio::GpioPeripheral& id_sense_peripheral,
+    tvsc::hal::gpio::PinNumber sense_pin, tvsc::hal::adc::AdcPeripheral& adc_peripheral) {
   using namespace tvsc::hal::board_identification;
   using namespace tvsc::hal::gpio;
   using namespace std::chrono_literals;

--- a/bringup/satellite.cc
+++ b/bringup/satellite.cc
@@ -52,11 +52,11 @@ class CanBusSniffer final : public tvsc::message::Processor<tvsc::message::CanBu
 class LedControl final : public tvsc::message::Processor<tvsc::message::CanBusMessage> {
  private:
   tvsc::hal::gpio::GpioPeripheral* led_gpio_peripheral_;
-  tvsc::hal::gpio::Pin led_pin_;
+  tvsc::hal::gpio::PinNumber led_pin_;
   tvsc::hal::gpio::Gpio led_gpio_{};
 
  public:
-  LedControl(tvsc::hal::gpio::GpioPeripheral& led_gpio_peripheral, tvsc::hal::gpio::Pin led_pin)
+  LedControl(tvsc::hal::gpio::GpioPeripheral& led_gpio_peripheral, tvsc::hal::gpio::PinNumber led_pin)
       : led_gpio_peripheral_(&led_gpio_peripheral), led_pin_(led_pin) {}
 
   bool process(const tvsc::message::CanBusMessage& msg) override {

--- a/bringup/satellite.cc
+++ b/bringup/satellite.cc
@@ -56,7 +56,8 @@ class LedControl final : public tvsc::message::Processor<tvsc::message::CanBusMe
   tvsc::hal::gpio::Gpio led_gpio_{};
 
  public:
-  LedControl(tvsc::hal::gpio::GpioPeripheral& led_gpio_peripheral, tvsc::hal::gpio::PinNumber led_pin)
+  LedControl(tvsc::hal::gpio::GpioPeripheral& led_gpio_peripheral,
+             tvsc::hal::gpio::PinNumber led_pin)
       : led_gpio_peripheral_(&led_gpio_peripheral), led_pin_(led_pin) {}
 
   bool process(const tvsc::message::CanBusMessage& msg) override {
@@ -115,9 +116,8 @@ int main(int argc, char* argv[]) {
 
   system.scheduler().add_task(periodic_transmit(system.board().can1(), 10s, announce_msg));
 
-  system.scheduler().add_task(can_bus_receive(
-      system.board().can1(), can_bus_message_queue,
-      system.board().gpio<System::BoardType::DEBUG_LED_PORT>(), System::BoardType::DEBUG_LED_PIN));
+  system.scheduler().add_task(
+      can_bus_receive(system.board().can1(), can_bus_message_queue, system.board().debug_led()));
 
   system.scheduler().add_task(process_messages(can_bus_message_queue));
 

--- a/bringup/systick_blink_demo.cc
+++ b/bringup/systick_blink_demo.cc
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
 
   tvsc::hal::gpio::GpioPeripheral& gpio_peripheral{board.gpio<BoardType::DEBUG_LED_PORT>()};
   tvsc::hal::gpio::Gpio gpio{gpio_peripheral.access()};
-  tvsc::hal::gpio::Pin pin{BoardType::DEBUG_LED_PIN};
+  tvsc::hal::gpio::PinNumber pin{BoardType::DEBUG_LED_PIN};
 
   gpio.set_pin_mode(pin, tvsc::hal::gpio::PinMode::OUTPUT_PUSH_PULL);
 

--- a/bringup/watchdog_demo.cc
+++ b/bringup/watchdog_demo.cc
@@ -21,8 +21,7 @@ int main(int argc, char* argv[]) {
   System::clock().sleep(CYCLE_TIME);
 
   System::scheduler().add_task(run_watchdog(System::board().iwdg()));
-  System::scheduler().add_task(
-      blink(System::board().gpio<BoardType::DEBUG_LED_PORT>(), BoardType::DEBUG_LED_PIN));
+  System::scheduler().add_task(blink(System::board().debug_led()));
   System::scheduler().add_task(quit(CYCLE_TIME));
   System::scheduler().start();
 }

--- a/hal/adc/adc.h
+++ b/hal/adc/adc.h
@@ -31,16 +31,16 @@ class AdcPeripheral : public Peripheral<AdcPeripheral, Adc> {
    * want begin/end iterators as parameters. (Note: can't use std::array as it would require
    * templating on the size of the array, and template functions can't be virtual.
    */
-  virtual void start_single_conversion(gpio::PortPin pin, uint32_t* destination,
+  virtual void start_single_conversion(gpio::PinRef pin, uint32_t* destination,
                                        size_t destination_buffer_size) = 0;
 
-  virtual void start_conversion_stream(gpio::PortPin pin, uint32_t* destination,
+  virtual void start_conversion_stream(gpio::PinRef pin, uint32_t* destination,
                                        size_t destination_buffer_size, timer::Timer& trigger) = 0;
 
   /**
    * Measure the voltage on a pin. This method blocks until the conversion is complete.
    */
-  virtual uint16_t measure_value(gpio::PortPin pin, std::chrono::milliseconds timeout) = 0;
+  virtual uint16_t measure_value(gpio::PinRef pin, std::chrono::milliseconds timeout) = 0;
 
   virtual void reset_after_conversion() = 0;
 
@@ -77,17 +77,17 @@ class Adc final : public Functional<AdcPeripheral, Adc> {
   friend class Peripheral<AdcPeripheral, Adc>;
 
  public:
-  void start_single_conversion(gpio::PortPin pin, uint32_t* destination,
+  void start_single_conversion(gpio::PinRef pin, uint32_t* destination,
                                size_t destination_buffer_size) {
     peripheral_->start_single_conversion(pin, destination, destination_buffer_size);
   }
 
-  void start_conversion_stream(gpio::PortPin pin, uint32_t* destination,
+  void start_conversion_stream(gpio::PinRef pin, uint32_t* destination,
                                size_t destination_buffer_size, timer::Timer& trigger) {
     peripheral_->start_conversion_stream(pin, destination, destination_buffer_size, trigger);
   }
 
-  uint16_t measure_value(gpio::PortPin pin, std::chrono::milliseconds timeout = 10ms) {
+  uint16_t measure_value(gpio::PinRef pin, std::chrono::milliseconds timeout = 10ms) {
     return peripheral_->measure_value(pin, timeout);
   }
 

--- a/hal/adc/stm32l4xx_adc.cc
+++ b/hal/adc/stm32l4xx_adc.cc
@@ -29,7 +29,7 @@ uint32_t trigger_flag(PeripheralId trigger_id) {
   error();
 }
 
-static constexpr uint32_t get_channel(gpio::PortPin pin) {
+static constexpr uint32_t get_channel(gpio::PinRef pin) {
   if (pin.port == 0) {
     if (pin.pin == 0) {
       // ADC1_IN5
@@ -67,7 +67,7 @@ static constexpr uint32_t get_channel(gpio::PortPin pin) {
   error();
 }
 
-void AdcStm32l4xx::start_conversion_stream(gpio::PortPin pin, uint32_t* destination,
+void AdcStm32l4xx::start_conversion_stream(gpio::PinRef pin, uint32_t* destination,
                                            size_t destination_buffer_size, timer::Timer& trigger) {
   // Ensure the DMA controller is on.
   dma_ = dma_peripheral_->access();
@@ -117,7 +117,7 @@ void AdcStm32l4xx::start_conversion_stream(gpio::PortPin pin, uint32_t* destinat
   HAL_ADC_Start_DMA(&adc_, destination, destination_buffer_size);
 }
 
-void AdcStm32l4xx::start_single_conversion(gpio::PortPin pin, uint32_t* destination,
+void AdcStm32l4xx::start_single_conversion(gpio::PinRef pin, uint32_t* destination,
                                            size_t destination_buffer_size) {
   // Ensure the DMA controller is on.
   dma_ = dma_peripheral_->access();
@@ -167,7 +167,7 @@ void AdcStm32l4xx::start_single_conversion(gpio::PortPin pin, uint32_t* destinat
   HAL_ADC_Start_DMA(&adc_, destination, destination_buffer_size);
 }
 
-uint16_t AdcStm32l4xx::measure_value(gpio::PortPin pin, std::chrono::milliseconds timeout) {
+uint16_t AdcStm32l4xx::measure_value(gpio::PinRef pin, std::chrono::milliseconds timeout) {
   // Ensure the DMA controller is on.
   dma_ = dma_peripheral_->access();
 

--- a/hal/adc/stm32l4xx_adc.h
+++ b/hal/adc/stm32l4xx_adc.h
@@ -23,13 +23,13 @@ class AdcStm32l4xx final : public AdcPeripheral {
   void enable() override;
   void disable() override;
 
-  void start_single_conversion(gpio::PortPin pin, uint32_t* destination,
+  void start_single_conversion(gpio::PinRef pin, uint32_t* destination,
                                size_t destination_buffer_size) override;
 
-  void start_conversion_stream(gpio::PortPin pin, uint32_t* destination,
+  void start_conversion_stream(gpio::PinRef pin, uint32_t* destination,
                                size_t destination_buffer_size, timer::Timer& trigger) override;
 
-  uint16_t measure_value(gpio::PortPin pin, std::chrono::milliseconds timeout) override;
+  uint16_t measure_value(gpio::PinRef pin, std::chrono::milliseconds timeout) override;
 
   void reset_after_conversion() override;
 

--- a/hal/board/feature_bringup_board.h
+++ b/hal/board/feature_bringup_board.h
@@ -44,35 +44,35 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{6};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{6};
   static constexpr size_t NUM_DAC_CHANNELS{1};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
-  static constexpr gpio::Port GPIO_PORT_H{7};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_H{7};
 
   // Location of the pins to read the board id.
-  static constexpr gpio::Port BOARD_ID_POWER_PORT{GPIO_PORT_A};
-  static constexpr gpio::Port BOARD_ID_SENSE_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin BOARD_ID_POWER_PIN{6};
-  static constexpr gpio::Pin BOARD_ID_SENSE_PIN{7};
+  static constexpr gpio::PortNumber BOARD_ID_POWER_PORT{GPIO_PORT_A};
+  static constexpr gpio::PortNumber BOARD_ID_SENSE_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber BOARD_ID_POWER_PIN{6};
+  static constexpr gpio::PinNumber BOARD_ID_SENSE_PIN{7};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_B};
-  static constexpr gpio::Pin DEBUG_LED_PIN{0};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_B};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{0};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
-  static constexpr gpio::Port DAC_CHANNEL_1_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DAC_CHANNEL_1_PIN{4};
+  static constexpr gpio::PortNumber DAC_CHANNEL_1_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DAC_CHANNEL_1_PIN{4};
 
-  static constexpr std::array<gpio::Port, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
 
  private:
   rcc::RccStm32L4xx rcc_{};
@@ -135,8 +135,8 @@ class Board final {
 
   // Note that these GPIO Ports are disallowed on this board. They are marked private to make it
   // more difficult to accidentally use them.
-  static constexpr gpio::Port GPIO_PORT_F{5};
-  static constexpr gpio::Port GPIO_PORT_G{6};
+  static constexpr gpio::PortNumber GPIO_PORT_F{5};
+  static constexpr gpio::PortNumber GPIO_PORT_G{6};
   static constexpr size_t NUM_DISALLOWED_PORTS{2};
 
   static Board board_;
@@ -148,7 +148,7 @@ class Board final {
   // One board per executable.
   static Board& board();
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS + NUM_DISALLOWED_PORTS,
@@ -193,7 +193,7 @@ class Board final {
    * only be used as to lookup GPIO ports using integer values that can be evaluated at
    * compile-time; these integer values will mainly come from STM's HAL.
    */
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/nucleo_h743zi_board.h
+++ b/hal/board/nucleo_h743zi_board.h
@@ -19,33 +19,33 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{5};
-  static constexpr gpio::Port NUM_DAC_CHANNELS{2};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{5};
+  static constexpr gpio::PortNumber NUM_DAC_CHANNELS{2};
   static constexpr size_t NUM_DEBUG_LEDS{3};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
 
   // Location of the LEDs provided by this board.
   static constexpr size_t NUM_USER_LEDS{3};
-  static constexpr gpio::Port RED_LED_PORT{GPIO_PORT_B};
-  static constexpr gpio::Pin RED_LED_PIN{14};
-  static constexpr gpio::Port YELLOW_LED_PORT{GPIO_PORT_E};
-  static constexpr gpio::Pin YELLOW_LED_PIN{1};
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_B};
-  static constexpr gpio::Pin DEBUG_LED_PIN{0};
+  static constexpr gpio::PortNumber RED_LED_PORT{GPIO_PORT_B};
+  static constexpr gpio::PinNumber RED_LED_PIN{14};
+  static constexpr gpio::PortNumber YELLOW_LED_PORT{GPIO_PORT_E};
+  static constexpr gpio::PinNumber YELLOW_LED_PIN{1};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_B};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{0};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{
       RED_LED_PORT, YELLOW_LED_PORT, DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{RED_LED_PIN, YELLOW_LED_PIN,
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{RED_LED_PIN, YELLOW_LED_PIN,
                                                                         DEBUG_LED_PIN};
 
   // Location of the push button on this board.
-  static constexpr gpio::Port BLUE_PUSH_BUTTON_PORT{GPIO_PORT_C};
-  static constexpr gpio::Pin BLUE_PUSH_BUTTON_PIN{13};
+  static constexpr gpio::PortNumber BLUE_PUSH_BUTTON_PORT{GPIO_PORT_C};
+  static constexpr gpio::PinNumber BLUE_PUSH_BUTTON_PIN{13};
 
  private:
   rcc::RccStm32h7xx rcc_{reinterpret_cast<void*>(RCC_BASE), reinterpret_cast<void*>(SysTick_BASE),
@@ -66,7 +66,7 @@ class Board final {
   // Don't forget to modify NUM_GPIO_PORTS and add a GPIO_PORT_* above.
 
  public:
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::Gpio& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS,
@@ -90,7 +90,7 @@ class Board final {
     }
   }
 
-  gpio::Gpio& gpio(gpio::Port port) {
+  gpio::Gpio& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/nucleo_l412kb_board.h
+++ b/hal/board/nucleo_l412kb_board.h
@@ -30,21 +30,21 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{6};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{6};
   static constexpr size_t NUM_DAC_CHANNELS{0};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_H{7};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_H{7};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_B};
-  static constexpr gpio::Pin DEBUG_LED_PIN{3};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_B};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{3};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
  private:
   rcc::RccStm32L4xx rcc_{};
@@ -79,10 +79,10 @@ class Board final {
 
   // Note that these GPIO Ports are disallowed on this board. They are marked private to make it
   // more difficult to accidentally use them.
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
-  static constexpr gpio::Port GPIO_PORT_F{5};
-  static constexpr gpio::Port GPIO_PORT_G{6};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_F{5};
+  static constexpr gpio::PortNumber GPIO_PORT_G{6};
   static constexpr size_t NUM_DISALLOWED_PORTS{4};
 
   static Board board_;
@@ -94,7 +94,7 @@ class Board final {
   // One board per executable.
   static Board& board();
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS + NUM_DISALLOWED_PORTS,
@@ -139,7 +139,7 @@ class Board final {
     }
   }
 
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/nucleo_l432kc_board.h
+++ b/hal/board/nucleo_l432kc_board.h
@@ -31,30 +31,30 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{6};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{6};
   static constexpr size_t NUM_DAC_CHANNELS{2};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_H{7};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_H{7};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_B};
-  static constexpr gpio::Pin DEBUG_LED_PIN{3};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_B};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{3};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
-  static constexpr gpio::Port DAC_CHANNEL_1_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DAC_CHANNEL_1_PIN{4};
-  static constexpr gpio::Port DAC_CHANNEL_2_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DAC_CHANNEL_2_PIN{5};
+  static constexpr gpio::PortNumber DAC_CHANNEL_1_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DAC_CHANNEL_1_PIN{4};
+  static constexpr gpio::PortNumber DAC_CHANNEL_2_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DAC_CHANNEL_2_PIN{5};
 
-  static constexpr std::array<gpio::Port, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT,
+  static constexpr std::array<gpio::PortNumber, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT,
                                                                       DAC_CHANNEL_2_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN,
+  static constexpr std::array<gpio::PinNumber, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN,
                                                                     DAC_CHANNEL_2_PIN};
 
  private:
@@ -92,10 +92,10 @@ class Board final {
 
   // Note that these GPIO Ports are disallowed on this board. They are marked private to make it
   // more difficult to accidentally use them.
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
-  static constexpr gpio::Port GPIO_PORT_F{5};
-  static constexpr gpio::Port GPIO_PORT_G{6};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_F{5};
+  static constexpr gpio::PortNumber GPIO_PORT_G{6};
   static constexpr size_t NUM_DISALLOWED_PORTS{4};
 
   static Board board_;
@@ -107,7 +107,7 @@ class Board final {
   // One board per executable.
   static Board& board();
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS + NUM_DISALLOWED_PORTS,
@@ -152,7 +152,7 @@ class Board final {
     }
   }
 
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/nucleo_l452re_board.h
+++ b/hal/board/nucleo_l452re_board.h
@@ -36,33 +36,33 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{6};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{6};
   static constexpr size_t NUM_DAC_CHANNELS{1};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
-  static constexpr gpio::Port GPIO_PORT_H{7};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_H{7};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DEBUG_LED_PIN{5};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{5};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
   // Location of the push button on this board.
-  static constexpr gpio::Port BLUE_PUSH_BUTTON_PORT{GPIO_PORT_C};
-  static constexpr gpio::Pin BLUE_PUSH_BUTTON_PIN{13};
+  static constexpr gpio::PortNumber BLUE_PUSH_BUTTON_PORT{GPIO_PORT_C};
+  static constexpr gpio::PinNumber BLUE_PUSH_BUTTON_PIN{13};
 
-  static constexpr gpio::Port DAC_CHANNEL_1_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DAC_CHANNEL_1_PIN{4};
+  static constexpr gpio::PortNumber DAC_CHANNEL_1_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DAC_CHANNEL_1_PIN{4};
 
-  static constexpr std::array<gpio::Port, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
 
  private:
   rcc::RccStm32L4xx rcc_{};
@@ -107,8 +107,8 @@ class Board final {
 
   // Note that these GPIO Ports are disallowed on this board. They are marked private to make it
   // more difficult to accidentally use them.
-  static constexpr gpio::Port GPIO_PORT_F{5};
-  static constexpr gpio::Port GPIO_PORT_G{6};
+  static constexpr gpio::PortNumber GPIO_PORT_F{5};
+  static constexpr gpio::PortNumber GPIO_PORT_G{6};
   static constexpr size_t NUM_DISALLOWED_PORTS{2};
 
   static Board board_;
@@ -120,7 +120,7 @@ class Board final {
   // One board per executable.
   static Board& board();
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS + NUM_DISALLOWED_PORTS,
@@ -165,7 +165,7 @@ class Board final {
    * only be used as to lookup GPIO ports using integer values that can be evaluated at
    * compile-time; these integer values will mainly come from STM's HAL.
    */
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/satellite_board.h
+++ b/hal/board/satellite_board.h
@@ -225,6 +225,14 @@ class Board final {
 
   random::RngPeripheral& rng() { return rng_; }
 
+  gpio::PinPeripheral debug_led() {
+    return gpio::PinPeripheral{gpio<DEBUG_LED_PORT>(), DEBUG_LED_PIN};
+  }
+
+  gpio::PinPeripheral debug_led(size_t led_number) {
+    return gpio::PinPeripheral{gpio(DEBUG_LED_PORTS[led_number]), DEBUG_LED_PINS[led_number]};
+  }
+
   watchdog::WatchdogPeripheral& iwdg() { return iwdg_; }
 
   i2c::I2cPeripheral& i2c1() { return i2c1_; }

--- a/hal/board/satellite_board.h
+++ b/hal/board/satellite_board.h
@@ -44,35 +44,35 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{6};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{6};
   static constexpr size_t NUM_DAC_CHANNELS{1};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
-  static constexpr gpio::Port GPIO_PORT_B{1};
-  static constexpr gpio::Port GPIO_PORT_C{2};
-  static constexpr gpio::Port GPIO_PORT_D{3};
-  static constexpr gpio::Port GPIO_PORT_E{4};
-  static constexpr gpio::Port GPIO_PORT_H{7};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_B{1};
+  static constexpr gpio::PortNumber GPIO_PORT_C{2};
+  static constexpr gpio::PortNumber GPIO_PORT_D{3};
+  static constexpr gpio::PortNumber GPIO_PORT_E{4};
+  static constexpr gpio::PortNumber GPIO_PORT_H{7};
 
   // Location of the pins to read the board id.
-  static constexpr gpio::Port BOARD_ID_POWER_PORT{GPIO_PORT_A};
-  static constexpr gpio::Port BOARD_ID_SENSE_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin BOARD_ID_POWER_PIN{6};
-  static constexpr gpio::Pin BOARD_ID_SENSE_PIN{7};
+  static constexpr gpio::PortNumber BOARD_ID_POWER_PORT{GPIO_PORT_A};
+  static constexpr gpio::PortNumber BOARD_ID_SENSE_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber BOARD_ID_POWER_PIN{6};
+  static constexpr gpio::PinNumber BOARD_ID_SENSE_PIN{7};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_C};
-  static constexpr gpio::Pin DEBUG_LED_PIN{13};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_C};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{13};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
-  static constexpr gpio::Port DAC_CHANNEL_1_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DAC_CHANNEL_1_PIN{4};
+  static constexpr gpio::PortNumber DAC_CHANNEL_1_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DAC_CHANNEL_1_PIN{4};
 
-  static constexpr std::array<gpio::Port, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DAC_CHANNELS> DAC_PORTS{DAC_CHANNEL_1_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DAC_CHANNELS> DAC_PINS{DAC_CHANNEL_1_PIN};
 
  private:
   rcc::RccStm32L4xx rcc_{};
@@ -135,8 +135,8 @@ class Board final {
 
   // Note that these GPIO Ports are disallowed on this board. They are marked private to make it
   // more difficult to accidentally use them.
-  static constexpr gpio::Port GPIO_PORT_F{5};
-  static constexpr gpio::Port GPIO_PORT_G{6};
+  static constexpr gpio::PortNumber GPIO_PORT_F{5};
+  static constexpr gpio::PortNumber GPIO_PORT_G{6};
   static constexpr size_t NUM_DISALLOWED_PORTS{2};
 
   static Board board_;
@@ -148,7 +148,7 @@ class Board final {
   // One board per executable.
   static Board& board();
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS + NUM_DISALLOWED_PORTS,
@@ -193,7 +193,7 @@ class Board final {
    * only be used as to lookup GPIO ports using integer values that can be evaluated at
    * compile-time; these integer values will mainly come from STM's HAL.
    */
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_port_a_;
     } else if (port == 1) {

--- a/hal/board/simulation_board.h
+++ b/hal/board/simulation_board.h
@@ -33,18 +33,18 @@ namespace tvsc::hal::board {
 
 class Board final {
  public:
-  static constexpr gpio::Port NUM_GPIO_PORTS{1};
+  static constexpr gpio::PortNumber NUM_GPIO_PORTS{1};
   static constexpr size_t NUM_DAC_CHANNELS{0};
   static constexpr size_t NUM_DEBUG_LEDS{1};
 
-  static constexpr gpio::Port GPIO_PORT_A{0};
+  static constexpr gpio::PortNumber GPIO_PORT_A{0};
 
   // Location of the LEDs provided by this board.
-  static constexpr gpio::Port DEBUG_LED_PORT{GPIO_PORT_A};
-  static constexpr gpio::Pin DEBUG_LED_PIN{5};
+  static constexpr gpio::PortNumber DEBUG_LED_PORT{GPIO_PORT_A};
+  static constexpr gpio::PinNumber DEBUG_LED_PIN{5};
 
-  static constexpr std::array<gpio::Port, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
-  static constexpr std::array<gpio::Pin, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
+  static constexpr std::array<gpio::PortNumber, NUM_DEBUG_LEDS> DEBUG_LED_PORTS{DEBUG_LED_PORT};
+  static constexpr std::array<gpio::PinNumber, NUM_DEBUG_LEDS> DEBUG_LED_PINS{DEBUG_LED_PIN};
 
   // We use a simulation clock that gives one millisecond of time in the simulation for every
   // microsecond on the running system's steady_clock. This ratio simulates a much slower CPU than
@@ -94,7 +94,7 @@ class Board final {
 
   io::SessionDirectory& log_directory() noexcept { return log_directory_; }
 
-  template <gpio::Port GPIO_PORT>
+  template <gpio::PortNumber GPIO_PORT>
   gpio::GpioPeripheral& gpio() {
     static_assert(
         GPIO_PORT < NUM_GPIO_PORTS,
@@ -112,7 +112,7 @@ class Board final {
    * only be used as to lookup GPIO ports using integer values that can be evaluated at
    * compile-time; these integer values will mainly come from STM's HAL.
    */
-  gpio::GpioPeripheral& gpio(gpio::Port port) {
+  gpio::GpioPeripheral& gpio(gpio::PortNumber port) {
     if (port == 0) {
       return gpio_interceptor_;
     }

--- a/hal/board/simulation_board.h
+++ b/hal/board/simulation_board.h
@@ -119,6 +119,10 @@ class Board final {
     error();
   }
 
+  gpio::PinPeripheral debug_led() {
+    return gpio::PinPeripheral{gpio<DEBUG_LED_PORT>(), DEBUG_LED_PIN};
+  }
+
   watchdog::WatchdogPeripheral& iwdg() { return iwdg_interceptor_; }
   power::Power& power() { return power_interceptor_; };
   rcc::Rcc& rcc() { return rcc_interceptor_; };

--- a/hal/can_bus/stm32l4xx_can_bus.h
+++ b/hal/can_bus/stm32l4xx_can_bus.h
@@ -16,10 +16,10 @@ class CanBusStm32l4xx final : public CanBusPeripheral {
   CAN_HandleTypeDef can_bus_{};
   gpio::GpioPeripheral* gpio_peripheral_;
   gpio::Gpio gpio_{};
-  gpio::Pin tx_pin_;
-  gpio::Pin rx_pin_;
-  gpio::Pin shutdown_pin_;
-  gpio::Pin silent_pin_;
+  gpio::PinNumber tx_pin_;
+  gpio::PinNumber rx_pin_;
+  gpio::PinNumber shutdown_pin_;
+  gpio::PinNumber silent_pin_;
 
   void enable() override;
   void disable() override;
@@ -34,7 +34,7 @@ class CanBusStm32l4xx final : public CanBusPeripheral {
 
  public:
   CanBusStm32l4xx(CAN_TypeDef* can_bus_instance, gpio::GpioPeripheral& gpio_peripheral,
-                  gpio::Pin tx_pin, gpio::Pin rx_pin, gpio::Pin shutdown_pin, gpio::Pin silent_pin)
+                  gpio::PinNumber tx_pin, gpio::PinNumber rx_pin, gpio::PinNumber shutdown_pin, gpio::PinNumber silent_pin)
       : gpio_peripheral_(&gpio_peripheral),
         tx_pin_(tx_pin),
         rx_pin_(rx_pin),

--- a/hal/gpio/gpio.h
+++ b/hal/gpio/gpio.h
@@ -11,16 +11,16 @@ namespace tvsc::hal::gpio {
 /**
  * Type used to identify a GPIO port (specific peripheral) on an processor.
  */
-using Port = uint8_t;
+using PortNumber = uint8_t;
 
 /**
  * Type used to identify a Pin on a GPIO port.
  */
-using Pin = uint8_t;
+using PinNumber = uint8_t;
 
 struct PortPin final {
-  Port port{};
-  Pin pin{};
+  PortNumber port{};
+  PinNumber pin{};
 };
 
 /**
@@ -111,12 +111,12 @@ class GpioPeripheral : public Peripheral<GpioPeripheral, Gpio> {
   virtual void enable() = 0;
   virtual void disable() = 0;
 
-  virtual void set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+  virtual void set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                             uint8_t alternate_function_mapping) = 0;
 
-  virtual bool read_pin(Pin pin) = 0;
-  virtual void write_pin(Pin pin, bool on) = 0;
-  virtual void toggle_pin(Pin pin) = 0;
+  virtual bool read_pin(PinNumber pin) = 0;
+  virtual void write_pin(PinNumber pin, bool on) = 0;
+  virtual void toggle_pin(PinNumber pin) = 0;
 
   friend class Gpio;
 
@@ -126,7 +126,7 @@ class GpioPeripheral : public Peripheral<GpioPeripheral, Gpio> {
  public:
   virtual ~GpioPeripheral() = default;
 
-  virtual Port port() const = 0;
+  virtual PortNumber port() const = 0;
 };
 
 class Gpio final : public Functional<GpioPeripheral, Gpio> {
@@ -138,16 +138,16 @@ class Gpio final : public Functional<GpioPeripheral, Gpio> {
  public:
   Gpio() = default;
 
-  void set_pin_mode(Pin pin, PinMode mode, PinSpeed speed = PinSpeed::LOW,
+  void set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed = PinSpeed::LOW,
                     uint8_t alternate_function_mapping = 0) {
     peripheral_->set_pin_mode(pin, mode, speed, alternate_function_mapping);
   }
 
-  bool read_pin(Pin pin) { return peripheral_->read_pin(pin); }
-  void write_pin(Pin pin, bool on) { peripheral_->write_pin(pin, on); }
-  void toggle_pin(Pin pin) { peripheral_->toggle_pin(pin); }
+  bool read_pin(PinNumber pin) { return peripheral_->read_pin(pin); }
+  void write_pin(PinNumber pin, bool on) { peripheral_->write_pin(pin, on); }
+  void toggle_pin(PinNumber pin) { peripheral_->toggle_pin(pin); }
 
-  Port port() const { return peripheral_->port(); }
+  PortNumber port() const { return peripheral_->port(); }
 };
 
 }  // namespace tvsc::hal::gpio

--- a/hal/gpio/gpio.h
+++ b/hal/gpio/gpio.h
@@ -18,7 +18,10 @@ using PortNumber = uint8_t;
  */
 using PinNumber = uint8_t;
 
-struct PortPin final {
+/**
+ * Reference to a specific pin on a specific GPIO port.
+ */
+struct PinRef final {
   PortNumber port{};
   PinNumber pin{};
 };

--- a/hal/gpio/gpio_interceptor.h
+++ b/hal/gpio/gpio_interceptor.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <chrono>
-
 #include "hal/gpio/gpio.h"
 #include "hal/peripheral.h"
 #include "hal/simulation/interceptor.h"
@@ -25,28 +23,28 @@ class GpioInterceptor final : public simulation::Interceptor<GpioPeripheral, Clo
     return this->call(&GpioPeripheral::disable);
   }
 
-  void set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+  void set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                     uint8_t alternate_function_mapping) override {
     LOG_FN();
     return this->call(&GpioPeripheral::set_pin_mode, pin, mode, speed, alternate_function_mapping);
   }
 
-  bool read_pin(Pin pin) override {
+  bool read_pin(PinNumber pin) override {
     LOG_FN();
     return this->call(&GpioPeripheral::read_pin, pin);
   }
 
-  void write_pin(Pin pin, bool on) override {
+  void write_pin(PinNumber pin, bool on) override {
     LOG_FN();
     return this->call(&GpioPeripheral::write_pin, pin, on);
   }
 
-  void toggle_pin(Pin pin) override {
+  void toggle_pin(PinNumber pin) override {
     LOG_FN();
     return this->call(&GpioPeripheral::toggle_pin, pin);
   }
 
-  Port port() const override {
+  PortNumber port() const override {
     LOG_FN();
     return this->call(&GpioPeripheral::port);
   }

--- a/hal/gpio/gpio_noop.cc
+++ b/hal/gpio/gpio_noop.cc
@@ -1,20 +1,22 @@
 #include "hal/gpio/gpio_noop.h"
 
+#include "hal/gpio/gpio.h"
+
 namespace tvsc::hal::gpio {
 
 void GpioNoop::enable() {}
 
 void GpioNoop::disable() {}
 
-void GpioNoop::set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+void GpioNoop::set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                             uint8_t alternate_function_mapping) {}
 
-bool GpioNoop::read_pin(Pin pin) { return false; }
+bool GpioNoop::read_pin(PinNumber pin) { return false; }
 
-void GpioNoop::write_pin(Pin pin, bool on) {}
+void GpioNoop::write_pin(PinNumber pin, bool on) {}
 
-void GpioNoop::toggle_pin(Pin pin) {}
+void GpioNoop::toggle_pin(PinNumber pin) {}
 
-Port GpioNoop::port() const { return port_; }
+PortNumber GpioNoop::port() const { return port_; }
 
 }  // namespace tvsc::hal::gpio

--- a/hal/gpio/gpio_noop.h
+++ b/hal/gpio/gpio_noop.h
@@ -1,30 +1,27 @@
 #pragma once
 
-#include <chrono>
-
 #include "hal/gpio/gpio.h"
-#include "hal/peripheral.h"
 
 namespace tvsc::hal::gpio {
 
 class GpioNoop final : public GpioPeripheral {
-private:
-  Port port_;
+ private:
+  PortNumber port_;
 
-public:
-  GpioNoop(Port port) : port_(port) {}
+ public:
+  GpioNoop(PortNumber port) : port_(port) {}
 
   void enable() override;
   void disable() override;
 
-  void set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+  void set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                     uint8_t alternate_function_mapping) override;
 
-  bool read_pin(Pin pin) override;
-  void write_pin(Pin pin, bool on) override;
-  void toggle_pin(Pin pin) override;
+  bool read_pin(PinNumber pin) override;
+  void write_pin(PinNumber pin, bool on) override;
+  void toggle_pin(PinNumber pin) override;
 
-  Port port() const override;
+  PortNumber port() const override;
 };
 
 }  // namespace tvsc::hal::gpio

--- a/hal/gpio/stm_gpio.cc
+++ b/hal/gpio/stm_gpio.cc
@@ -1,5 +1,6 @@
 #include "hal/gpio/stm_gpio.h"
 
+#include <cstdint>
 #include <new>
 
 #include "hal/gpio/gpio.h"
@@ -9,7 +10,7 @@
 
 namespace tvsc::hal::gpio {
 
-void GpioStm32xxxx::set_ospeedr_value(Pin pin, PinSpeed speed) {
+void GpioStm32xxxx::set_ospeedr_value(PinNumber pin, PinSpeed speed) {
   uint8_t speed_value{};
   switch (speed) {
     case PinSpeed::LOW:
@@ -30,22 +31,22 @@ void GpioStm32xxxx::set_ospeedr_value(Pin pin, PinSpeed speed) {
   registers_->OSPEEDR.set_bit_field_value<2>(speed_value, static_cast<uint8_t>(2 * pin));
 }
 
-void GpioStm32xxxx::set_moder_value(Pin pin, MODER_VALUES value) {
+void GpioStm32xxxx::set_moder_value(PinNumber pin, MODER_VALUES value) {
   registers_->MODER.set_bit_field_value<2>(static_cast<uint32_t>(value),
                                            static_cast<uint8_t>(2 * pin));
 }
 
-void GpioStm32xxxx::set_pupdr_value(Pin pin, OPUPDR_VALUES value) {
+void GpioStm32xxxx::set_pupdr_value(PinNumber pin, OPUPDR_VALUES value) {
   registers_->OPUPDR.set_bit_field_value<2>(static_cast<uint32_t>(value),
                                             static_cast<uint8_t>(2 * pin));
 }
 
-void GpioStm32xxxx::set_otyper_value(Pin pin, OTYPER_VALUES value) {
+void GpioStm32xxxx::set_otyper_value(PinNumber pin, OTYPER_VALUES value) {
   registers_->OTYPER.set_bit_field_value<1>(static_cast<uint32_t>(value),
                                             static_cast<uint8_t>(pin));
 }
 
-void GpioStm32xxxx::set_alternate_function(Pin pin, uint8_t value) {
+void GpioStm32xxxx::set_alternate_function(PinNumber pin, uint8_t value) {
   if (pin >= 0 && pin < 8) {
     registers_->AFRL.set_bit_field_value<4>(value, 4 * pin);
   } else {
@@ -53,7 +54,7 @@ void GpioStm32xxxx::set_alternate_function(Pin pin, uint8_t value) {
   }
 }
 
-void GpioStm32xxxx::set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+void GpioStm32xxxx::set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                                  uint8_t alternate_function_mapping) {
   switch (mode) {
       // Unused pins get set to the reset state of most pins. Note that the reset state of some
@@ -185,7 +186,7 @@ void GpioStm32xxxx::set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
   }
 }
 
-void GpioStm32xxxx::write_pin(Pin pin, bool on) {
+void GpioStm32xxxx::write_pin(PinNumber pin, bool on) {
   // Atomically turn on or off the pin. Setting a one in the lower 16-bits turns ON the pin.
   // Setting a one in the upper 16-bits turns OFF the pin.
   if (on) {
@@ -195,13 +196,13 @@ void GpioStm32xxxx::write_pin(Pin pin, bool on) {
   }
 }
 
-void GpioStm32xxxx::toggle_pin(Pin pin) {
+void GpioStm32xxxx::toggle_pin(PinNumber pin) {
   const uint32_t current_value{registers_->ODR.value()};
   registers_->BSRR.set_value(((current_value & (1U << pin)) << NUM_PINS) |
                              (~current_value & (1U << pin)));
 }
 
-bool GpioStm32xxxx::read_pin(Pin pin) { return registers_->IDR.bit_field_value<1>(pin); }
+bool GpioStm32xxxx::read_pin(PinNumber pin) { return registers_->IDR.bit_field_value<1>(pin); }
 
 void GpioStm32xxxx::disable() {
   if (port_ == 0) {
@@ -243,6 +244,6 @@ void GpioStm32xxxx::enable() {
   }
 }
 
-Port GpioStm32xxxx::port() const { return port_; }
+PortNumber GpioStm32xxxx::port() const { return port_; }
 
 }  // namespace tvsc::hal::gpio

--- a/hal/gpio/stm_gpio.h
+++ b/hal/gpio/stm_gpio.h
@@ -57,9 +57,9 @@ class GpioRegisterBank final {
 class GpioStm32xxxx final : public GpioPeripheral {
  private:
   GpioRegisterBank* registers_;
-  const Port port_;
+  const PortNumber port_;
 
-  void set_ospeedr_value(Pin pin, PinSpeed speed);
+  void set_ospeedr_value(PinNumber pin, PinSpeed speed);
 
   enum class MODER_VALUES : uint8_t {
     INPUT = 0b00,
@@ -67,41 +67,41 @@ class GpioStm32xxxx final : public GpioPeripheral {
     ALTERNATE_FUNCTION = 0b10,
     ANALOG = 0b11,
   };
-  void set_moder_value(Pin pin, MODER_VALUES value);
+  void set_moder_value(PinNumber pin, MODER_VALUES value);
 
   enum class OPUPDR_VALUES : uint8_t {
     BOTH_DISABLED = 0x00,
     PULL_UP_ENABLED = 0b01,
     PULL_DOWN_ENABLED = 0b10,
   };
-  void set_pupdr_value(Pin pin, OPUPDR_VALUES value);
+  void set_pupdr_value(PinNumber pin, OPUPDR_VALUES value);
 
   enum class OTYPER_VALUES : uint8_t {
     MOSFET_PUSH_PULL = 0b0,
     MOSFET_OPEN_DRAIN = 0b1,
   };
-  void set_otyper_value(Pin pin, OTYPER_VALUES value);
+  void set_otyper_value(PinNumber pin, OTYPER_VALUES value);
 
-  void set_alternate_function(Pin pin, uint8_t value);
+  void set_alternate_function(PinNumber pin, uint8_t value);
 
   void enable() override;
   void disable() override;
 
-  void set_pin_mode(Pin pin, PinMode mode, PinSpeed speed,
+  void set_pin_mode(PinNumber pin, PinMode mode, PinSpeed speed,
                     uint8_t alternate_function_mapping) override;
 
-  void write_pin(Pin pin, bool on) override;
-  void toggle_pin(Pin pin) override;
+  void write_pin(PinNumber pin, bool on) override;
+  void toggle_pin(PinNumber pin) override;
 
-  bool read_pin(Pin pin) override;
+  bool read_pin(PinNumber pin) override;
 
  public:
   static constexpr size_t NUM_PINS{16};
 
-  GpioStm32xxxx(void* base_address, Port port)
-      : registers_(new (base_address) GpioRegisterBank), port_(port) {}
+  GpioStm32xxxx(void* base_address, PortNumber port)
+      : registers_(new(base_address) GpioRegisterBank), port_(port) {}
 
-  Port port() const override;
+  PortNumber port() const override;
 };
 
 }  // namespace tvsc::hal::gpio

--- a/hal/i2c/stm32l4xx_i2c.h
+++ b/hal/i2c/stm32l4xx_i2c.h
@@ -17,8 +17,8 @@ class I2cStm32l4xx final : public I2cPeripheral {
   Callback pending_callback_;
   gpio::GpioPeripheral* gpio_peripheral_;
   gpio::Gpio gpio_{};
-  gpio::Pin scl_pin_;
-  gpio::Pin sda_pin_;
+  gpio::PinNumber scl_pin_;
+  gpio::PinNumber sda_pin_;
 
   void enable() override;
   void disable() override;
@@ -58,8 +58,8 @@ class I2cStm32l4xx final : public I2cPeripheral {
                         size_t length, Callback callback) override;
 
  public:
-  I2cStm32l4xx(I2C_TypeDef* i2c_instance, gpio::GpioPeripheral& gpio_peripheral, gpio::Pin scl_pin,
-               gpio::Pin sda_pin)
+  I2cStm32l4xx(I2C_TypeDef* i2c_instance, gpio::GpioPeripheral& gpio_peripheral, gpio::PinNumber scl_pin,
+               gpio::PinNumber sda_pin)
       : gpio_peripheral_(&gpio_peripheral), scl_pin_(scl_pin), sda_pin_(sda_pin) {
     i2c_.Instance = i2c_instance;
   }

--- a/hal/peripheral.h
+++ b/hal/peripheral.h
@@ -125,6 +125,13 @@ class Functional {
     return *this;
   }
 
+  void ensure_valid(PeripheralType& peripheral) {
+    if (peripheral_ == nullptr) {
+      peripheral_ = &peripheral;
+      peripheral_->inc_ref_count();
+    }
+  }
+
   void invalidate() {
     if (peripheral_ != nullptr) {
       peripheral_->dec_ref_count();

--- a/hal/programmer/stm32l4xx_programmer.h
+++ b/hal/programmer/stm32l4xx_programmer.h
@@ -25,9 +25,9 @@ class ProgrammerStm32l4xx final : public ProgrammerPeripheral {
  private:
   gpio::GpioPeripheral* gpio_peripheral_;
   gpio::Gpio gpio_{};
-  gpio::Pin swdio_pin_;
-  gpio::Pin swclk_pin_;
-  gpio::Pin reset_pin_;
+  gpio::PinNumber swdio_pin_;
+  gpio::PinNumber swclk_pin_;
+  gpio::PinNumber reset_pin_;
   uint32_t half_clock_period_cycles_{};
   SwdioDriveState current_swdio_drive_state_{SwdioDriveState::FLOAT};
 
@@ -58,8 +58,8 @@ class ProgrammerStm32l4xx final : public ProgrammerPeripheral {
   bool receive(uint32_t& data, uint8_t bits_to_receive) override;
 
  public:
-  ProgrammerStm32l4xx(gpio::GpioPeripheral& gpio_peripheral, gpio::Pin swdio_pin,
-                      gpio::Pin swclk_pin, gpio::Pin reset_pin)
+  ProgrammerStm32l4xx(gpio::GpioPeripheral& gpio_peripheral, gpio::PinNumber swdio_pin,
+                      gpio::PinNumber swclk_pin, gpio::PinNumber reset_pin)
       : gpio_peripheral_(&gpio_peripheral),
         swdio_pin_(swdio_pin),
         swclk_pin_(swclk_pin),

--- a/hal/timer/timer.h
+++ b/hal/timer/timer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
 
 #include "hal/gpio/gpio.h"
 #include "hal/peripheral.h"


### PR DESCRIPTION
Create PinPeripheral, Pin, and PinRef classes to allow the passing of pin and GPIO port numbers as a single object. The PinPeripheral and Pin follow the Peripheral/Functional RAII pattern where gaining access to the actual functionality requires powering and clocking the GPIO port.

The PinRef class is a simple struct of the integer values of the port and pin, without any additional functionality.
